### PR TITLE
更改错误：不存在的gulp-tester；删除一些在注释后面的空格

### DIFF
--- a/source/_posts/Butterfly-安裝文檔-六-進階教程.md
+++ b/source/_posts/Butterfly-安裝文檔-六-進階教程.md
@@ -206,7 +206,7 @@ const cleanCSS = require('gulp-clean-css')
 const htmlmin = require('gulp-html-minifier-terser')
 const htmlclean = require('gulp-htmlclean')
 const imagemin = require('gulp-imagemin')
-// gulp-tester (如果使用 gulp-tester,把下面的//去掉)
+// gulp-terser (如果使用 gulp-terser,把下面的//去掉)
 //const terser = require('gulp-terser');
 
 // babel (如果不是使用bebel,把下面兩行註釋掉)
@@ -225,7 +225,7 @@ gulp.task('compress', () =>
     .pipe(gulp.dest('./public'))
 )
 
-// minify js - gulp-tester (如果使用 gulp-tester,把下面前面的//去掉)
+// minify js - gulp-terser (如果使用 gulp-terser,把下面前面的//去掉)
 //gulp.task('compress', () =>
 //  gulp.src(['./public/**/*.js', '!./public/**/*.min.js'])
 //    .pipe(terser())
@@ -630,7 +630,7 @@ const htmlmin = require('gulp-html-minifier-terser')
 const htmlclean = require('gulp-htmlclean')
 const imagemin = require('gulp-imagemin')
 const workbox = require("workbox-build");
-// gulp-tester (如果使用 gulp-terser,把下面的//去掉)
+// gulp-terser (如果使用 gulp-terser,把下面的//去掉)
 // const terser = require('gulp-terser');
 
 // babel
@@ -664,7 +664,7 @@ gulp.task('compress', () =>
 		.pipe(gulp.dest('./public'))
 );
 
-// minify js - gulp-tester (如果使用 gulp-tester,把下面前面的//去掉)
+// minify js - gulp-terser (如果使用 gulp-terser,把下面前面的//去掉)
 // gulp.task('compress', () =>
 //   gulp.src(['./public/**/*.js', '!./public/**/*.min.js'])
 //     .pipe(terser())

--- a/source/_posts/Butterfly-安裝文檔-六-進階教程.md
+++ b/source/_posts/Butterfly-安裝文檔-六-進階教程.md
@@ -207,7 +207,7 @@ const htmlmin = require('gulp-html-minifier-terser')
 const htmlclean = require('gulp-htmlclean')
 const imagemin = require('gulp-imagemin')
 // gulp-tester (如果使用 gulp-tester,把下面的//去掉)
-// const terser = require('gulp-terser');
+//const terser = require('gulp-terser');
 
 // babel (如果不是使用bebel,把下面兩行註釋掉)
 const uglify = require('gulp-uglify')
@@ -226,10 +226,10 @@ gulp.task('compress', () =>
 )
 
 // minify js - gulp-tester (如果使用 gulp-tester,把下面前面的//去掉)
-// gulp.task('compress', () =>
-//   gulp.src(['./public/**/*.js', '!./public/**/*.min.js'])
-//     .pipe(terser())
-//     .pipe(gulp.dest('./public'))
+//gulp.task('compress', () =>
+//  gulp.src(['./public/**/*.js', '!./public/**/*.min.js'])
+//    .pipe(terser())
+//    .pipe(gulp.dest('./public'))
 // )
 
 
@@ -630,7 +630,7 @@ const htmlmin = require('gulp-html-minifier-terser')
 const htmlclean = require('gulp-htmlclean')
 const imagemin = require('gulp-imagemin')
 const workbox = require("workbox-build");
-// gulp-tester (如果使用 gulp-tester,把下面的//去掉)
+// gulp-tester (如果使用 gulp-terser,把下面的//去掉)
 // const terser = require('gulp-terser');
 
 // babel


### PR DESCRIPTION
gulp-tester不存在，正确存在的是：gulp-terser
一些在注释（//）后面存在一个空格，且提示不明显，没有提示要把"//"后面的空格删除，故删除部分在"/"后面的空格